### PR TITLE
Including unistd.h

### DIFF
--- a/src/cvrKernel/CalVR.cpp
+++ b/src/cvrKernel/CalVR.cpp
@@ -21,7 +21,9 @@
 #include <vector>
 #include <cstring>
 
-#ifdef WIN32
+#ifndef WIN32
+#include <unistd.h>
+#else
 #include <Winsock2.h>
 #include <stdlib.h>
 #pragma comment(lib, "wsock32.lib")

--- a/src/cvrKernel/ComController.cpp
+++ b/src/cvrKernel/ComController.cpp
@@ -16,7 +16,9 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef WIN32
+#ifndef WIN32
+#include <unistd.h>
+#else
 #pragma comment(lib, "wsock32.lib")
 #endif
 

--- a/src/cvrUtil/CVRMulticastSocket.cpp
+++ b/src/cvrUtil/CVRMulticastSocket.cpp
@@ -1,6 +1,7 @@
 #include <cvrUtil/CVRMulticastSocket.h>
 
 #ifndef WIN32
+#include <unistd.h>
 #include <arpa/inet.h>
 #endif
 

--- a/src/cvrUtil/CVRSocket.cpp
+++ b/src/cvrUtil/CVRSocket.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 
 #ifndef WIN32
+#include <unistd.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <fcntl.h>

--- a/src/cvrUtil/MultiListenSocket.cpp
+++ b/src/cvrUtil/MultiListenSocket.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #ifndef WIN32
+#include <unistd.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <fcntl.h>


### PR DESCRIPTION
# include <unistd.h> is needed in many files, without which CalVR is failing to compile under Ubuntu 12.04, gcc (Ubuntu/Linaro 4.7.2-2ubuntu1) 4.7.2.

It was only included for non-WIN32 systems.
