### PR TITLE
Compile fix

### DIFF
--- a/src/cvrUtil/CVRMulticastSocket.cpp
+++ b/src/cvrUtil/CVRMulticastSocket.cpp
@@ -20,7 +20,7 @@ CVRMulticastSocket::CVRMulticastSocket(MCSocketType st,
     _port = port;
 
     _socket = (int)socket(AF_INET,SOCK_DGRAM,0);
-    if(socket < 0)
+    if(_socket < 0)
     {
         std::cerr << "CVRMulticastSocket: error creating socket." << std::endl;
         return;


### PR DESCRIPTION
The below failed to compile for me on macOS with the following error:
```
ordered comparison between pointer and zero ('int (*)(int, int, int)' and 'int')
```
I _think_ that the intention here is to test the socket that was _returned_ for zero and not the function `socket()`. But I cannot easily test this code and therefore cannot confirm this assumption.